### PR TITLE
[MWRAPPER-43] Make jar download quiet by default

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvn/wrapper/MavenWrapperDownloader.java
+++ b/maven-wrapper-distribution/src/resources/mvn/wrapper/MavenWrapperDownloader.java
@@ -26,6 +26,8 @@ public class MavenWrapperDownloader
 {
     private static final String WRAPPER_VERSION = "@project.version@";
 
+    private static final boolean VERBOSE = Boolean.parseBoolean( System.getenv( "MVNW_VERBOSE" ) );
+
     /**
      * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
      */
@@ -51,9 +53,9 @@ public class MavenWrapperDownloader
 
     public static void main( String args[] )
     {
-        System.out.println( "- Downloader started" );
+        log( " - Downloader started" );
         File baseDirectory = new File( args[0] );
-        System.out.println( "- Using base directory: " + baseDirectory.getAbsolutePath() );
+        log( " - Using base directory: " + baseDirectory.getAbsolutePath() );
 
         // If the maven-wrapper.properties exists, read it and check if it contains a custom
         // wrapperUrl parameter.
@@ -71,7 +73,7 @@ public class MavenWrapperDownloader
             }
             catch ( IOException e )
             {
-                System.out.println( "- ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'" );
+                System.err.println( " - ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'" );
             }
             finally
             {
@@ -88,27 +90,27 @@ public class MavenWrapperDownloader
                 }
             }
         }
-        System.out.println( "- Downloading from: " + url );
+        log( " - Downloading from: " + url );
 
         File outputFile = new File( baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH );
         if ( !outputFile.getParentFile().exists() )
         {
             if ( !outputFile.getParentFile().mkdirs() )
             {
-                System.out.println( "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath()
+                System.err.println( "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath()
                     + "'" );
             }
         }
-        System.out.println( "- Downloading to: " + outputFile.getAbsolutePath() );
+        log( " - Downloading to: " + outputFile.getAbsolutePath() );
         try
         {
             downloadFileFromURL( url, outputFile );
-            System.out.println( "Done" );
+            log( "Done" );
             System.exit( 0 );
         }
         catch ( Throwable e )
         {
-            System.out.println( "- Error downloading" );
+            System.err.println( "- Error downloading" );
             e.printStackTrace();
             System.exit( 1 );
         }
@@ -137,6 +139,14 @@ public class MavenWrapperDownloader
         fos.getChannel().transferFrom( rbc, 0, Long.MAX_VALUE );
         fos.close();
         rbc.close();
+    }
+
+    private static void log( String msg )
+    {
+        if ( VERBOSE )
+        {
+            System.out.println( msg );
+        }
     }
 
 }

--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -233,22 +233,26 @@ else
     fi
 
     if command -v wget > /dev/null; then
+        QUIET="--quiet"
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Found wget ... using wget"
+          QUIET=""
         fi
         if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            wget "$jarUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+            wget $QUIET "$jarUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
         else
-            wget --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+            wget $QUIET --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$jarUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
         fi
     elif command -v curl > /dev/null; then
+        QUIET="--silent"
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Found curl ... using curl"
+          QUIET=""
         fi
         if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            curl -o "$wrapperJarPath" "$jarUrl" -f
+            curl $QUIET -o "$wrapperJarPath" "$jarUrl" -f
         else
-            curl --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
+            curl $QUIET --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$jarUrl" -f
         fi
 
     else


### PR DESCRIPTION
This adds `--quiet` to wget and `--silent` to curl by default, and only when MVNW_VERBOSE is set to true it prints the download information.

Also the MavenWrapperDownloader.java is modified to read and print based on MVNW_VERBOSE.