### PR TITLE
Don't ignore dependabot branches for shared GH v2

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -19,8 +19,6 @@ name: Verify
 
 on:
   push:
-    branches-ignore:
-      - dependabot/**
   pull_request:
 
 jobs:


### PR DESCRIPTION
From v2 for shared GitHub Action duplicate build on PR are skipped in script,
so we shouldn't ignore dependabot branches