### PR TITLE
[MWRAPPER-23] Get maven user home (~/.m2) with the same logic with maven

### DIFF
--- a/maven-wrapper/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
+++ b/maven-wrapper/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
@@ -45,10 +45,6 @@ public class MavenWrapperMain
 
     private static final Path DEFAULT_MAVEN_USER_HOME = Paths.get( System.getProperty( "user.home" ) ).resolve( ".m2" );
 
-    public static final String MAVEN_USER_HOME_PROPERTY_KEY = "maven.user.home";
-
-    public static final String MAVEN_USER_HOME_ENV_KEY = "MAVEN_USER_HOME";
-
     public static final String MVNW_VERBOSE = "MVNW_VERBOSE";
 
     public static final String MVNW_USERNAME = "MVNW_USERNAME";
@@ -148,12 +144,6 @@ public class MavenWrapperMain
 
     private static Path mavenUserHome()
     {
-        String mavenUserHome = System.getProperty( MAVEN_USER_HOME_PROPERTY_KEY );
-        if ( mavenUserHome == null )
-        {
-            mavenUserHome = System.getenv( MAVEN_USER_HOME_ENV_KEY );
-        }
-
-        return mavenUserHome == null ? DEFAULT_MAVEN_USER_HOME : Paths.get( mavenUserHome );
+        return DEFAULT_MAVEN_USER_HOME;
     }
 }


### PR DESCRIPTION
New maven wrapper will guess the maven user home location via system props, system envs
and at last the default location (`~/.m2`).
This guessing order is the convention of the gradle wrapper.
For maven, user home has a fixed location, i.e. `~/.m2`.