### PR TITLE
[MWRAPPER-60] place maven-wrapper.jar into ~/.m2/wrapper/dists

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -198,44 +198,55 @@ concat_lines() {
   fi
 }
 
+# hash string like Java String::hashCode
+hash_string() {
+  local str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    h=$(( ( h * 31 + $(LC_CTYPE=C printf %d "'$str") ) % 4294967296 ))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
 BASE_DIR=`find_maven_basedir "$(pwd)"`
 if [ -z "$BASE_DIR" ]; then
   exit 1;
 fi
 
-MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}; export MAVEN_PROJECTBASEDIR
+MAVEN_PROJECTBASEDIR="$BASE_DIR"; export MAVEN_PROJECTBASEDIR
 if [ "$MVNW_VERBOSE" = true ]; then
   echo $MAVEN_PROJECTBASEDIR
 fi
+
+# maven-wrapper path
+wrapperUrl="${MVNW_REPOURL:-https://repo.maven.apache.org/maven2}/org/apache/maven/wrapper/maven-wrapper/@project.version@/maven-wrapper-@project.version@.jar"
+while IFS="=" read key value; do
+  case "$key" in (wrapperUrl) wrapperUrl="$value"; break ;;
+  esac
+done < "$BASE_DIR/.mvn/wrapper/maven-wrapper.properties"
+wrapperJarPath="$HOME/.m2/wrapper/dists/maven-wrapper/$(hash_string "$wrapperUrl")/maven-wrapper.jar"
+if $cygwin; then
+  wrapperJarPath="`cygpath --path --windows "$wrapperJarPath"`"
+fi
+
 
 ##########################################################################################
 # Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
 # This allows using the maven wrapper in projects that prohibit checking in binary data.
 ##########################################################################################
-if [ -r "$BASE_DIR/.mvn/wrapper/maven-wrapper.jar" ]; then
+if [ -r "$wrapperJarPath" ]; then
     if [ "$MVNW_VERBOSE" = true ]; then
-      echo "Found .mvn/wrapper/maven-wrapper.jar"
+      echo "Found $wrapperJarPath"
     fi
-else
+elif [ ! -e "$(dirname -- "$wrapperJarPath")" ] && TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -n "$TMP_DOWNLOAD_DIR" -a -d "$TMP_DOWNLOAD_DIR" ]; then
     if [ "$MVNW_VERBOSE" = true ]; then
-      echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
-    fi
-    if [ -n "$MVNW_REPOURL" ]; then
-      wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/@project.version@/maven-wrapper-@project.version@.jar"
-    else
-      wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/@project.version@/maven-wrapper-@project.version@.jar"
-    fi
-    while IFS="=" read key value; do
-      case "$key" in (wrapperUrl) wrapperUrl="$value"; break ;;
-      esac
-    done < "$BASE_DIR/.mvn/wrapper/maven-wrapper.properties"
-    if [ "$MVNW_VERBOSE" = true ]; then
+      echo "Couldn't find $wrapperJarPath, downloading it ..."
       echo "Downloading from: $wrapperUrl"
+      echo "Downloading to tmp dir: $TMP_DOWNLOAD_DIR"
     fi
-    wrapperJarPath="$BASE_DIR/.mvn/wrapper/maven-wrapper.jar"
-    if $cygwin; then
-      wrapperJarPath=`cygpath --path --windows "$wrapperJarPath"`
-    fi
+
+    tmpWrapperJarPath="$TMP_DOWNLOAD_DIR/$(basename -- "$wrapperJarPath")"
+    printf %s\\n "$wrapperUrl" > "$TMP_DOWNLOAD_DIR/url.txt"
 
     if command -v wget > /dev/null; then
         QUIET="--quiet"
@@ -244,9 +255,9 @@ else
           QUIET=""
         fi
         if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            wget $QUIET "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+            wget $QUIET "$wrapperUrl" -O "$tmpWrapperJarPath"
         else
-            wget $QUIET --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+            wget $QUIET --http-user=$MVNW_USERNAME --http-password=$MVNW_PASSWORD "$wrapperUrl" -O "$tmpWrapperJarPath"
         fi
     elif command -v curl > /dev/null; then
         QUIET="--silent"
@@ -255,12 +266,12 @@ else
           QUIET=""
         fi
         if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
-            curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f
+            curl $QUIET -o "$tmpWrapperJarPath" "$wrapperUrl" -f
         else
-            curl $QUIET --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$wrapperJarPath" "$wrapperUrl" -f
+            curl $QUIET --user $MVNW_USERNAME:$MVNW_PASSWORD -o "$tmpWrapperJarPath" "$wrapperUrl" -f
         fi
-
     else
+        # TODO this branch depends on https://github.com/apache/maven-wrapper/pull/30
         if [ "$MVNW_VERBOSE" = true ]; then
           echo "Falling back to using Java to download"
         fi
@@ -288,6 +299,17 @@ else
             fi
         fi
     fi
+
+    # move to dest path
+    if [ -r "$tmpWrapperJarPath" -a -s "$tmpWrapperJarPath" ] && mkdir -p -- "$(dirname -- "$(dirname -- "$wrapperJarPath")")"; then
+        if ! mv -- "$TMP_DOWNLOAD_DIR" "$(dirname -- "$wrapperJarPath")"; then
+          if [ "$MVNW_VERBOSE" = true ]; then
+            echo " - Skip replace existing $wrapperJarPath ..."
+          fi
+        fi
+    fi
+
+    [ ! -d "$TMP_DOWNLOAD_DIR" ] || rm -rf -- "$TMP_DOWNLOAD_DIR"
 fi
 ##########################################################################################
 # End of extension
@@ -317,7 +339,7 @@ WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 exec "$JAVACMD" \
   $MAVEN_OPTS \
   $MAVEN_DEBUG_OPTS \
-  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  -classpath "$wrapperJarPath" \
   "-Dmaven.home=${M2_HOME}" \
   "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
   ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/maven-wrapper-distribution/src/resources/mvnw.cmd
+++ b/maven-wrapper-distribution/src/resources/mvnw.cmd
@@ -85,9 +85,6 @@ goto error
 @REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
 @REM Fallback to current working directory if not found.
 
-set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
-IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
-
 set EXEC_DIR=%CD%
 set WDIR=%EXEC_DIR%
 :findBaseDir

--- a/maven-wrapper/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
+++ b/maven-wrapper/src/main/java/org/apache/maven/wrapper/MavenWrapperMain.java
@@ -102,8 +102,8 @@ public class MavenWrapperMain
 
     private static Path wrapperProperties( Path wrapperJar )
     {
-        return wrapperJar.resolveSibling( wrapperJar.getFileName().toString().replaceFirst( "\\.jar$",
-                                                                                            ".properties" ) );
+        return Paths.get( System.getProperty( "maven.multiModuleProjectDirectory" )
+                     + "/.mvn/wrapper/maven-wrapper.properties" );
     }
 
     private static Path wrapperJar()


### PR DESCRIPTION
1. place maven-wrapper.jar at
   `~/.m2/wrapper/dists/maven-wrapper/<url-hash>/` dir
2. now, `mvnw` script is updated and tested
3. remove undocumented and unused variable MAVEN_BASEDIR, like maven 4
4. resolve property file from maven.multiModuleProjectDirectory
5. the fallback branch (downloading via java) depends on #30 