### PR TITLE
[MWRAPPER-65] MavenWrapperDownloader.java ignores the MVNW_REPOURL env

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvn/wrapper/MavenWrapperDownloader.java
+++ b/maven-wrapper-distribution/src/resources/mvn/wrapper/MavenWrapperDownloader.java
@@ -23,12 +23,9 @@ import java.net.Authenticator;
 import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
-import java.util.Properties;
 
 public final class MavenWrapperDownloader
 {
@@ -36,72 +33,40 @@ public final class MavenWrapperDownloader
 
     private static final boolean VERBOSE = Boolean.parseBoolean( System.getenv( "MVNW_VERBOSE" ) );
 
-    /**
-     * Default URL to download the maven-wrapper.jar from, if no 'downloadUrl' is provided.
-     */
-    private static final String DEFAULT_DOWNLOAD_URL =
-        "https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/" + WRAPPER_VERSION
-            + "/maven-wrapper-" + WRAPPER_VERSION + ".jar";
-
-    /**
-     * Path to the maven-wrapper.properties file, which might contain a downloadUrl property to use instead of the
-     * default one.
-     */
-    private static final String MAVEN_WRAPPER_PROPERTIES_PATH = ".mvn/wrapper/maven-wrapper.properties";
-
-    /**
-     * Path where the maven-wrapper.jar will be saved to.
-     */
-    private static final String MAVEN_WRAPPER_JAR_PATH = ".mvn/wrapper/maven-wrapper.jar";
-
-    /**
-     * Name of the property which should be used to override the default download url for the wrapper.
-     */
-    private static final String PROPERTY_NAME_WRAPPER_URL = "wrapperUrl";
-
     public static void main( String[] args )
     {
-        if ( args.length == 0 )
+        log( "Apache Maven Wrapper Downloader " + WRAPPER_VERSION );
+
+        if ( args.length != 2 )
         {
-            System.err.println( " - ERROR projectBasedir parameter missing" );
+            System.err.println( " - ERROR wrapperUrl or wrapperJarPath parameter missing" );
             System.exit( 1 );
         }
-
-        log( " - Downloader started" );
-        final String dir = args[0].replace( "..", "" ); // Sanitize path
-        final Path projectBasedir = Paths.get( dir ).toAbsolutePath().normalize();
-        if ( !Files.isDirectory( projectBasedir, LinkOption.NOFOLLOW_LINKS ) )
-        {
-            System.err.println( " - ERROR projectBasedir not exists: " + projectBasedir );
-            System.exit( 1 );
-        }
-
-        log( " - Using base directory: " + projectBasedir );
-
-        // If the maven-wrapper.properties exists, read it and check if it contains a custom
-        // wrapperUrl parameter.
-        Path mavenWrapperPropertyFile = projectBasedir.resolve( MAVEN_WRAPPER_PROPERTIES_PATH );
-        String url = readWrapperUrl( mavenWrapperPropertyFile );
 
         try
         {
-            Path outputFile = projectBasedir.resolve( MAVEN_WRAPPER_JAR_PATH );
-            createDirectories( outputFile.getParent() );
-            downloadFileFromURL( url, outputFile );
+            log( " - Downloader started" );
+            final URL wrapperUrl = new URL( args[0] );
+            final String jarPath = args[1].replace( "..", "" ); // Sanitize path
+            final Path wrapperJarPath = Paths.get( jarPath ).toAbsolutePath().normalize();
+            downloadFileFromURL( wrapperUrl, wrapperJarPath );
             log( "Done" );
-            System.exit( 0 );
         }
         catch ( IOException e )
         {
-            System.err.println( "- Error downloading" );
-            e.printStackTrace();
+            System.err.println( "- Error downloading: " + e.getMessage() );
+            if ( VERBOSE )
+            {
+                e.printStackTrace();
+            }
             System.exit( 1 );
         }
     }
 
-    private static void downloadFileFromURL( String urlString, Path destination ) throws IOException
+    private static void downloadFileFromURL( URL wrapperUrl, Path wrapperJarPath )
+        throws IOException
     {
-        log( " - Downloading to: " + destination );
+        log( " - Downloading to: " + wrapperJarPath );
         if ( System.getenv( "MVNW_USERNAME" ) != null && System.getenv( "MVNW_PASSWORD" ) != null )
         {
             final String username = System.getenv( "MVNW_USERNAME" );
@@ -115,40 +80,11 @@ public final class MavenWrapperDownloader
                 }
             } );
         }
-        URL website = new URL( urlString );
-        try ( InputStream inStream = website.openStream() ) {
-            Files.copy( inStream, destination, StandardCopyOption.REPLACE_EXISTING );
+        try ( InputStream inStream = wrapperUrl.openStream() )
+        {
+            Files.copy( inStream, wrapperJarPath, StandardCopyOption.REPLACE_EXISTING );
         }
         log( " - Downloader complete" );
-    }
-
-    private static void createDirectories(Path outputPath) throws IOException
-    {
-        if ( !Files.isDirectory( outputPath, LinkOption.NOFOLLOW_LINKS ) ) {
-            Path createDirectories = Files.createDirectories( outputPath );
-            log( " - Directories created: " + createDirectories );
-        }
-    }
-
-    private static String readWrapperUrl( Path mavenWrapperPropertyFile )
-    {
-        String url = DEFAULT_DOWNLOAD_URL;
-        if ( Files.exists( mavenWrapperPropertyFile, LinkOption.NOFOLLOW_LINKS ) )
-        {
-            log( " - Reading property file: " + mavenWrapperPropertyFile );
-            try ( InputStream in = Files.newInputStream( mavenWrapperPropertyFile, StandardOpenOption.READ ) )
-            {
-                Properties mavenWrapperProperties = new Properties();
-                mavenWrapperProperties.load( in );
-                url = mavenWrapperProperties.getProperty( PROPERTY_NAME_WRAPPER_URL, DEFAULT_DOWNLOAD_URL );
-            }
-            catch ( IOException e )
-            {
-                System.err.println( " - ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'" );
-            }
-        }
-        log( " - Downloading from: " + url );
-        return url;
     }
 
     private static void log( String msg )

--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -164,28 +164,30 @@ concat_lines() {
   fi
 }
 
+log() {
+  if [ "$MVNW_VERBOSE" = true ]; then
+    printf '%s\n' "$1"
+  fi
+}
+
 BASE_DIR=$(find_maven_basedir "$(dirname $0)")
 if [ -z "$BASE_DIR" ]; then
   exit 1;
 fi
 
 MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}; export MAVEN_PROJECTBASEDIR
-if [ "$MVNW_VERBOSE" = true ]; then
-  echo $MAVEN_PROJECTBASEDIR
-fi
+log $MAVEN_PROJECTBASEDIR
 
 ##########################################################################################
 # Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
 # This allows using the maven wrapper in projects that prohibit checking in binary data.
 ##########################################################################################
-if [ -r "$BASE_DIR/.mvn/wrapper/maven-wrapper.jar" ]; then
-    if [ "$MVNW_VERBOSE" = true ]; then
-      echo "Found .mvn/wrapper/maven-wrapper.jar"
-    fi
+wrapperJarPath="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
+if [ -r "$wrapperJarPath" ]; then
+    log "Found $wrapperJarPath"
 else
-    if [ "$MVNW_VERBOSE" = true ]; then
-      echo "Couldn't find .mvn/wrapper/maven-wrapper.jar, downloading it ..."
-    fi
+    log "Couldn't find $wrapperJarPath, downloading it ..."
+
     if [ -n "$MVNW_REPOURL" ]; then
       wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/@@project.version@@/maven-wrapper-@@project.version@@.jar"
     else
@@ -194,21 +196,16 @@ else
     while IFS="=" read key value; do
       case "$key" in (wrapperUrl) wrapperUrl="$value"; break ;;
       esac
-    done < "$BASE_DIR/.mvn/wrapper/maven-wrapper.properties"
-    if [ "$MVNW_VERBOSE" = true ]; then
-      echo "Downloading from: $wrapperUrl"
-    fi
-    wrapperJarPath="$BASE_DIR/.mvn/wrapper/maven-wrapper.jar"
+    done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+    log "Downloading from: $wrapperUrl"
+
     if $cygwin; then
       wrapperJarPath=`cygpath --path --windows "$wrapperJarPath"`
     fi
 
     if command -v wget > /dev/null; then
-        QUIET="--quiet"
-        if [ "$MVNW_VERBOSE" = true ]; then
-          echo "Found wget ... using wget"
-          QUIET=""
-        fi
+        log "Found wget ... using wget"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
         if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
             wget $QUIET "$wrapperUrl" -O "$wrapperJarPath"
         else
@@ -216,11 +213,8 @@ else
         fi
         [ $? -eq 0 ] || rm -f "$wrapperJarPath"
     elif command -v curl > /dev/null; then
-        QUIET="--silent"
-        if [ "$MVNW_VERBOSE" = true ]; then
-          echo "Found curl ... using curl"
-          QUIET=""
-        fi
+        log "Found curl ... using curl"
+        [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
         if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
             curl $QUIET -o "$wrapperJarPath" "$wrapperUrl" -f -L
         else
@@ -228,11 +222,9 @@ else
         fi
         [ $? -eq 0 ] || rm -f "$wrapperJarPath"
     else
-        if [ "$MVNW_VERBOSE" = true ]; then
-          echo "Falling back to using Java to download"
-        fi
-        javaSource="$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.java"
-        javaClass="$BASE_DIR/.mvn/wrapper/MavenWrapperDownloader.class"
+        log "Falling back to using Java to download"
+        javaSource="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.java"
+        javaClass="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.class"
         # For Cygwin, switch paths to Windows format before running javac
         if $cygwin; then
           javaSource=`cygpath --path --windows "$javaSource"`
@@ -240,18 +232,13 @@ else
         fi
         if [ -e "$javaSource" ]; then
             if [ ! -e "$javaClass" ]; then
-                if [ "$MVNW_VERBOSE" = true ]; then
-                  echo " - Compiling MavenWrapperDownloader.java ..."
-                fi
-                # Compiling the Java class
+                log " - Compiling MavenWrapperDownloader.java ..."
                 ("$JAVA_HOME/bin/javac" "$javaSource")
             fi
             if [ -e "$javaClass" ]; then
-                # Running the downloader
-                if [ "$MVNW_VERBOSE" = true ]; then
-                  echo " - Running MavenWrapperDownloader.java ..."
-                fi
-                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$MAVEN_PROJECTBASEDIR")
+                log " - Running MavenWrapperDownloader.java ..."
+                ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$wrapperUrl" "$wrapperJarPath")
+                [ $? -eq 0 ] || rm -f "$wrapperJarPath"
             fi
         fi
     fi


### PR DESCRIPTION
This simplifies the MavenWrapperDownloader.java script by removing many of the redundant code that was already done on the shell script, fixing the problem when MVNW_REPOURL env variable was used but not read by the MavenWrapperDownloader.java.

Also wrap the calls when MVNW_VERBOSE is used to a log function in the shell script.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MWRAPPER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MWRAPPER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MWRAPPER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

