### PR TITLE
[MWRAPPER-67] Remove '\r' when using IFS on windows for wrapperUrl from mvnw script usage such as git bash

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -199,7 +199,9 @@ else
       wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/@@project.version@@/maven-wrapper-@@project.version@@.jar"
     fi
     while IFS="=" read -r key value; do
-      case "$key" in (wrapperUrl) wrapperUrl="$value"; break ;;
+      # Remove '\r' from value to allow usage on windows as IFS does not consider '\r' as a separator ( considers space, tab, new line ('\n'), and custom '=' )
+      safeValue=$(echo "$value" | tr -d '\r')
+      case "$key" in (wrapperUrl) wrapperUrl="$safeValue"; break ;;
       esac
     done < "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
     log "Downloading from: $wrapperUrl"


### PR DESCRIPTION
Usage of git bash will not download the maven wrapper jar along with curl (probably others) due to having windows line endings in the URL (trailing).  To ensure that is not the case, make sure to strip invalid line endings out before usage.

Use case, ./mvnw in powershell will use mvnw.cmd and has no issues downloading.  If user does same in git bash, it will fail with invalid URL error with curl.  Using ./mvnw.cmd there will work but not natural usage.  To ensure this simply just works for full support, trim out invalid line feeds.

note: This only affected the download.  It worked otherwise.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MWRAPPER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [ x] Each commit in the pull request should have a meaningful subject line and body.
 - [ x] Format the pull request title like `[MWRAPPER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MWRAPPER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [ x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x ] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

