### PR TITLE
[MWRAPPER-95] Fix bug in mvnw to handle \r in jvm.config correctly

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -160,7 +160,12 @@ find_maven_basedir() {
 # concatenates all lines of a file
 concat_lines() {
   if [ -f "$1" ]; then
-    tr -s '\n' ' ' < "$1"
+    # Remove \r in case we run on Windows within Git Bash
+    # and check out the repository with auto CRLF management
+    # enabled. Otherwise, we may read lines that are delimited with
+    # \r\n and produce $'-Xarg\r' rather than -Xarg due to word
+    # splitting rules.
+    tr -s '\r\n' ' ' < "$1"
   fi
 }
 


### PR DESCRIPTION
Addresses a similar issue (not the same, but similar) as #44.

If Git checks out the jvm.config file with CRLF line endings, a condition can arise in Git Bash where \r does not get removed, resulting in -Xarg becoming $'-Xarg\r' and breaking builds on Windows. This is reproducible in environments like GitHub Actions runners.

I was using a GitHub Actions runner on windows-2022, using a manual step with the "bash" shell. This job was in a matrix running the same command and step on ubuntu-2022 and macos-12 runners.

The repository used the default CRLF settings provided by Git, and the issue was produced by this jvm.config:

```
-XX:+TieredCompilation -XX:TieredStopAtLevel=1
```

Builds on MacOS and Linux were fine.

On the Windows runner, I came across this when invoking mvnw:

```console
$ ./mvnw -B -U -Dcheckstyle.skip=true -Dlicense.skip=true clean verify
Improperly specified VM option 'TieredStopAtLevel=1
'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

Upon enabling xtrace in the shell, the issue was verified to be that the jvm.config was being executed as:

```
> exec /c/hostedtoolcache/windows/Java_Zulu_jdk/19.0.2-7/x64/bin/java -XX:+TieredCompilation $'-XX:TieredStopAtLevel=1\r' ...
```

Updating .gitattributes to the following mediated this:

```
*         text=auto     eol=lf
*.cmd     text=auto     eol=crlf
*.jar     -text
```

...however, this was not immediately clear that this was the actual issue, which may be confusing or unexpected for new users, or those who do not have the knowledge in shell scripts/Git or do not have the time to dig down into this issue.

Since there is usually not a valid use case for providing newline literals in JVM arguments anyway, and this behaviour is not uniform across the CMD and the Bourne Shell runner, this change should not impact existing users.

---

Assuming since this is a 2 character change that this does not need a JIRA associated, under the note of trivial changes.

ICLA already signed for previous contributions to Surefire, and sent to the secretary.

---

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

