### PR TITLE
Log wrapper download class to stderr

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvn/wrapper/MavenWrapperDownloader.java
+++ b/maven-wrapper-distribution/src/resources/mvn/wrapper/MavenWrapperDownloader.java
@@ -91,7 +91,7 @@ public final class MavenWrapperDownloader
     {
         if ( VERBOSE )
         {
-            System.out.println( msg );
+            System.err.println( msg );
         }
     }
 


### PR DESCRIPTION
Log output of the wrapper download class to stderr rather than stdout. This enables it to not trample across cases where users may be piping mvnw output to a
command.

E.g.

    tag="v$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)"
    git push origin "${tag}"

Other output from this class already writes to stderr, so this enables full consistency.

Alternative would be to pipe stdout to stderr in each script, which is mostly just more work than changing this at the source.

This would become important for #71 where it may be more common to not include the JAR at all and only include the java file, since this could result in tripping up some distributed CI workflows.

Since this is a 3 character change, assuming it falls under the category of "trivial changes" that do not need a JIRA.

ICLA signed from previous contributions to Surefire, and submitted to the secretary.

 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

