### PR TITLE
[MWRAPPER-112] Detection of JAVA_HOME fails due to bad quoting

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -100,17 +100,17 @@ fi
 
 if [ -z "$JAVA_HOME" ]; then
   javaExecutable="$(which javac)"
-  if [ -n "$javaExecutable" ] && ! [ "$(expr "\"$javaExecutable\"" : '\([^ ]*\)')" = "no" ]; then
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "$javaExecutable" : '\([^ ]*\)')" = "no" ]; then
     # readlink(1) is not available as standard on Solaris 10.
     readLink=$(which readlink)
     if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
       if $darwin; then
-        javaHome="$(dirname "\"$javaExecutable\"")"
-        javaExecutable="$(cd "\"$javaHome\"" && pwd -P)/javac"
+        javaHome="$(dirname "$javaExecutable")"
+        javaExecutable="$(cd "$javaHome" && pwd -P)/javac"
       else
-        javaExecutable="$(readlink -f "\"$javaExecutable\"")"
+        javaExecutable="$(readlink -f "$javaExecutable")"
       fi
-      javaHome="$(dirname "\"$javaExecutable\"")"
+      javaHome="$(dirname "$javaExecutable")"
       javaHome=$(expr "$javaHome" : '\(.*\)/bin')
       JAVA_HOME="$javaHome"
       export JAVA_HOME


### PR DESCRIPTION
On a standard Ubuntu 20.04 Java installation (openjdk-17-jdk APT package, /usr/bin/javac linked to /usr/lib/jvm/java-17-openjdk-amd64/bin/javac via the update-alternatives system, no JAVA_HOME set), Maven Wrapper 3.2.0 prints this warning on each invocation:
> Warning: JAVA_HOME environment variable is not set.

This is caused by excessive quoting that adds literal double quotes to the resolution of javaHome and javaExecutable. (Some nearby invocations of "expr" use correct quoting, but several are wrong. There might have been obscure bugs and someone thought that more quoting is better. That code has been in the codebase since the beginning, taken over from the gradlew wrapper (which had the shell wrappers completely rewritten; there are no remnants of this code found there any longer).) With the literal quotes, the file system lookup fails to resolve the directory, and the auto-detection of JAVA_HOME fails, causing that warning.


Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MWRAPPER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MWRAPPER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MWRAPPER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).