### PR TITLE
[MWRAPPER-113] Some mvnw error and warning output goes to standard output

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -91,7 +91,7 @@ if $mingw; then
   [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] \
     && JAVA_HOME="$(
       cd "$JAVA_HOME" || (
-        echo "cannot cd into $JAVA_HOME."
+        echo "cannot cd into $JAVA_HOME." >&2
         exit 1
       )
       pwd
@@ -141,14 +141,14 @@ if [ ! -x "$JAVACMD" ]; then
 fi
 
 if [ -z "$JAVA_HOME" ]; then
-  echo "Warning: JAVA_HOME environment variable is not set."
+  echo "Warning: JAVA_HOME environment variable is not set." >&2
 fi
 
 # traverses directory structure from process work directory to filesystem root
 # first directory with .mvn subdirectory is considered project base directory
 find_maven_basedir() {
   if [ -z "$1" ]; then
-    echo "Path not specified to find_maven_basedir"
+    echo "Path not specified to find_maven_basedir" >&2
     return 1
   fi
 
@@ -292,8 +292,8 @@ if [ -n "$wrapperSha256Sum" ]; then
       wrapperSha256Result=true
     fi
   else
-    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available."
-    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties."
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   fi
   if [ $wrapperSha256Result = false ]; then

--- a/maven-wrapper-distribution/src/resources/mvnw.cmd
+++ b/maven-wrapper-distribution/src/resources/mvnw.cmd
@@ -59,22 +59,22 @@ set ERROR_CODE=0
 @REM ==== START VALIDATION ====
 if not "%JAVA_HOME%" == "" goto OkJHome
 
-echo.
+echo. >&2
 echo Error: JAVA_HOME not found in your environment. >&2
 echo Please set the JAVA_HOME variable in your environment to match the >&2
 echo location of your Java installation. >&2
-echo.
+echo. >&2
 goto error
 
 :OkJHome
 if exist "%JAVA_HOME%\bin\java.exe" goto init
 
-echo.
+echo. >&2
 echo Error: JAVA_HOME is set to an invalid directory. >&2
 echo JAVA_HOME = "%JAVA_HOME%" >&2
 echo Please set the JAVA_HOME variable in your environment to match the >&2
 echo location of your Java installation. >&2
-echo.
+echo. >&2
 goto error
 
 @REM ==== END VALIDATION ====
@@ -162,9 +162,9 @@ IF NOT %WRAPPER_SHA_256_SUM%=="" (
     powershell -Command "&{"^
        "$hash = (Get-FileHash \"%WRAPPER_JAR%\" -Algorithm SHA256).Hash.ToLower();"^
        "If('%WRAPPER_SHA_256_SUM%' -ne $hash){"^
-       "  Write-Output 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
-       "  Write-Output 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
-       "  Write-Output 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
+       "  Write-Error 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
+       "  Write-Error 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
+       "  Write-Error 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
        "  exit 1;"^
        "}"^
        "}"


### PR DESCRIPTION
Errors and warnings from the wrapper should go to standard error, so that those are also shown to the user when the regular Maven output is suppressed, redirected into a file, or captured by a script.
For the latter use case, separation is especially critical because otherwise error output is mistakenly interpreted as desired Maven output (for example, when obtaining the list of Maven project names in the reactor with `mvnw --quiet -Dexec.executable=echo '-Dexec.args=${project.groupId}:${project.artifactId}' org.codehaus.mojo:exec-maven-plugin:exec`).
The current wrapper scripts do this only inconsistently, and so warnings like `Warning: JAVA_HOME environment variable is not set.` are printed to _stdout_ instead of _stderr_.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MWRAPPER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MWRAPPER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MWRAPPER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

