### PR TITLE
[MWRAPPER-114] - Maven wrapper relative distributionUrl does not work…

### DIFF
--- a/maven-wrapper/src/main/java/org/apache/maven/wrapper/PathAssembler.java
+++ b/maven-wrapper/src/main/java/org/apache/maven/wrapper/PathAssembler.java
@@ -73,7 +73,11 @@ public class PathAssembler {
     }
 
     private String getBaseName(URI distUrl) {
-        return Paths.get(distUrl.getPath()).getFileName().toString();
+        if (distUrl.getScheme().equals("file")) {
+            return Paths.get(distUrl).getFileName().toString();
+        } else {
+            return Paths.get(distUrl.getPath()).getFileName().toString();
+        }
     }
 
     private Path getBaseDir(String base) {

--- a/maven-wrapper/src/test/java/org/apache/maven/wrapper/PathAssemblerTest.java
+++ b/maven-wrapper/src/test/java/org/apache/maven/wrapper/PathAssemblerTest.java
@@ -105,6 +105,17 @@ public class PathAssemblerTest {
         assertThat(dist.getParent().getParent(), equalTo(file(currentDirPath() + "/somePath/maven-1.0")));
     }
 
+    @Test
+    void distZipWithLocalWindowsPath() throws Exception {
+        configuration.setZipBase(PathAssembler.PROJECT_STRING);
+        configuration.setDistribution(new URI("file:///C:/maven-1.0.zip"));
+
+        Path dist = pathAssembler.getDistribution(configuration).getZipFile();
+        assertThat(dist.getFileName().toString(), equalTo("maven-1.0.zip"));
+        assertThat(dist.getParent().getFileName().toString(), matchesRegexp("[a-z0-9]+"));
+        assertThat(dist.getParent().getParent(), equalTo(file(currentDirPath() + "/somePath/maven-1.0")));
+    }
+
     private Path file(String path) {
         return Paths.get(path);
     }


### PR DESCRIPTION
… on Windows

There is a Path -> URI -> Path roundtrip which was being incorrectly carried out. For Windows file URIs like

file:///C:/test

calling distUrl.getPath() resulted in /C:/test, which Paths.get could not handle. Existing behaviour is preserved for non-file URIs

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MWRAPPER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MWRAPPER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MWRAPPER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`)**This fails, but so does master. I could not find any documentation on how to create a suitable development environment to have the tests pass**

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

