### PR TITLE
[MWRAPPER-129][MWRAPPER-128] Drop legacy stuff, require Maven 3.6.3+

### DIFF
--- a/maven-wrapper-plugin/pom.xml
+++ b/maven-wrapper-plugin/pom.xml
@@ -34,7 +34,7 @@ under the License.
   <description>The Maven Wrapper Plugin is a plugin that provides support for the Maven Wrapper by unpacking Maven Wrapper Distribution to the current project.</description>
 
   <prerequisites>
-    <maven>3.2.5</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <dependencies>

--- a/maven-wrapper-plugin/pom.xml
+++ b/maven-wrapper-plugin/pom.xml
@@ -34,7 +34,7 @@ under the License.
   <description>The Maven Wrapper Plugin is a plugin that provides support for the Maven Wrapper by unpacking Maven Wrapper Distribution to the current project.</description>
 
   <prerequisites>
-    <maven>${mavenVersion}</maven>
+    <maven>3.2.5</maven>
   </prerequisites>
 
   <dependencies>
@@ -57,11 +57,6 @@ under the License.
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-shared-utils</artifactId>
-      <version>3.4.2</version>
-    </dependency>
-    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>
@@ -82,10 +77,17 @@ under the License.
       <version>3.4.2</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
-      <version>1.1.0</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>1.9.18</version>
       <scope>provided</scope>
+    </dependency>
+
+    <!-- ONLY: MessageUtil -->
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
+      <version>3.4.2</version>
     </dependency>
 
     <!-- dependencies to annotations -->
@@ -109,7 +111,6 @@ under the License.
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/maven-wrapper/pom.xml
+++ b/maven-wrapper/pom.xml
@@ -31,23 +31,6 @@ under the License.
   <name>Maven Wrapper Jar</name>
   <description>Maven Wrapper Jar download, installs and launches installed target Maven distribution as part of Maven Wrapper scripts run.</description>
 
-  <properties>
-    <junit.version>5.10.2</junit.version>
-    <mockito.version>4.11.0</mockito.version>
-  </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${junit.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -63,7 +46,7 @@ under the License.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
+      <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,22 @@ under the License.
 
   <properties>
     <maven.site.path>wrapper-archives/wrapper-LATEST</maven.site.path>
-    <mavenVersion>3.2.5</mavenVersion>
+    <mavenVersion>3.9.6</mavenVersion>
     <javaVersion>8</javaVersion>
     <project.build.outputTimestamp>2023-03-08T23:06:24Z</project.build.outputTimestamp>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.10.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
Also refresh and reshuffle to not duplicate dependencies and versions. Tend to use properties for versions where there is 2+ of them, otherwise is just fluff.

---

https://issues.apache.org/jira/browse/MWRAPPER-128
https://issues.apache.org/jira/browse/MWRAPPER-129