### PR TITLE
[MWRAPPER-132][MWRAPPER-124] port MWRAPPER-124 fix to only-script

### DIFF
--- a/maven-wrapper-distribution/src/resources/only-mvnw
+++ b/maven-wrapper-distribution/src/resources/only-mvnw
@@ -199,7 +199,7 @@ elif set_java_home; then
 	  public static void main( String[] args ) throws Exception
 	  {
 	    setDefault( new Downloader() );
-	    java.nio.file.Files.copy( new java.net.URL( args[0] ).openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
 	  }
 	}
 	END


### PR DESCRIPTION
port pr https://github.com/apache/maven-wrapper/pull/120

Test Method:

```bash
sed -n '/public class Downloader/,/\t}/p' maven-wrapper-distribution/src/resources/only-mvnw > Downloader.java
jenv shell 21 ## or 1.7, 1.8, 11, 17
javac -version
javac Downloader.java -Xlint:all -Werror
```

Passed lint compile test with jdk 1.7, 1.8, 11, 17 and 21

---

https://issues.apache.org/jira/browse/MWRAPPER-132