### PR TITLE
[MWRAPPER-135] Provide a reliable way to determine the Maven Wrapper type

### DIFF
--- a/maven-wrapper-plugin/src/it/projects/default/verify.groovy
+++ b/maven-wrapper-plugin/src/it/projects/default/verify.groovy
@@ -35,3 +35,4 @@ new File(basedir,'.mvn/wrapper/maven-wrapper.properties').withInputStream {
     props.load(it)
 }
 assert props.wrapperVersion.equals(wrapperCurrentVersion)
+assert props.distributionType.equals("only-script")

--- a/maven-wrapper-plugin/src/it/projects/mavenversion/verify.groovy
+++ b/maven-wrapper-plugin/src/it/projects/mavenversion/verify.groovy
@@ -32,6 +32,7 @@ propertiesFile.withInputStream {
 }
 assert props.wrapperVersion.equals(wrapperCurrentVersion)
 assert props.distributionUrl.endsWith('/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip')
+assert props.distributionType.equals("only-script")
 
 log = new File(basedir, 'build.log').text
 // check "mvn wrapper:wrapper" output

--- a/maven-wrapper-plugin/src/it/projects/type_bin/verify.groovy
+++ b/maven-wrapper-plugin/src/it/projects/type_bin/verify.groovy
@@ -36,3 +36,4 @@ new File(basedir,'.mvn/wrapper/maven-wrapper.properties').withInputStream {
     props.load(it)
 }
 assert props.wrapperVersion.equals(wrapperCurrentVersion)
+assert props.distributionType.equals("bin")

--- a/maven-wrapper-plugin/src/it/projects/type_only-script/verify.groovy
+++ b/maven-wrapper-plugin/src/it/projects/type_only-script/verify.groovy
@@ -40,3 +40,4 @@ new File(basedir,'.mvn/wrapper/maven-wrapper.properties').withInputStream {
     props.load(it)
 }
 assert props.wrapperVersion.equals(wrapperCurrentVersion)
+assert props.distributionType.equals("only-script")

--- a/maven-wrapper-plugin/src/it/projects/type_script/verify.groovy
+++ b/maven-wrapper-plugin/src/it/projects/type_script/verify.groovy
@@ -41,3 +41,4 @@ new File(basedir,'.mvn/wrapper/maven-wrapper.properties').withInputStream {
     props.load(it)
 }
 assert props.wrapperVersion.equals(wrapperCurrentVersion)
+assert props.distributionType.equals("script")

--- a/maven-wrapper-plugin/src/it/projects/type_source/verify.groovy
+++ b/maven-wrapper-plugin/src/it/projects/type_source/verify.groovy
@@ -39,3 +39,4 @@ new File(basedir,'.mvn/wrapper/maven-wrapper.properties').withInputStream {
     props.load(it)
 }
 assert props.wrapperVersion.equals(wrapperCurrentVersion)
+assert props.distributionType.equals("source")

--- a/maven-wrapper-plugin/src/main/java/org/apache/maven/plugins/wrapper/WrapperMojo.java
+++ b/maven-wrapper-plugin/src/main/java/org/apache/maven/plugins/wrapper/WrapperMojo.java
@@ -288,6 +288,7 @@ public class WrapperMojo extends AbstractMojo {
         try (BufferedWriter out = Files.newBufferedWriter(wrapperPropertiesFile, StandardCharsets.UTF_8)) {
             out.append(String.format(Locale.ROOT, license));
             out.append("wrapperVersion=" + wrapperVersion + System.lineSeparator());
+            out.append("distributionType=" + distributionType + System.lineSeparator());
             out.append("distributionUrl=" + distributionUrl + System.lineSeparator());
             if (distributionSha256Sum != null) {
                 out.append("distributionSha256Sum=" + distributionSha256Sum + System.lineSeparator());


### PR DESCRIPTION
Adds `distributionType` to `maven-wrapper.properties`.

https://issues.apache.org/jira/browse/MWRAPPER-135