### PR TITLE
[MWRAPPER-141] Use distribution type of existing Maven Wrapper by default

### DIFF
--- a/maven-wrapper-plugin/src/it/projects/upgrade_with_existing_type/.mvn/wrapper/maven-wrapper.properties
+++ b/maven-wrapper-plugin/src/it/projects/upgrade_with_existing_type/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
+distributionType=bin
+wrapperVersion=3.3.1

--- a/maven-wrapper-plugin/src/it/projects/upgrade_with_existing_type/invoker.properties
+++ b/maven-wrapper-plugin/src/it/projects/upgrade_with_existing_type/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:wrapper -Dmaven=3.9.6
+invoker.goals.2 = exec:exec

--- a/maven-wrapper-plugin/src/it/projects/upgrade_with_existing_type/pom.xml
+++ b/maven-wrapper-plugin/src/it/projects/upgrade_with_existing_type/pom.xml
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.it.wrapper</groupId>
+  <artifactId>extension</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <cmd></cmd>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.0.0</version>
+          <configuration>
+            <executable>mvnw${cmd}</executable>
+            <arguments>
+              <argument>-v</argument>
+            </arguments>
+            <environmentVariables>
+              <MVNW_VERBOSE>true</MVNW_VERBOSE>
+            </environmentVariables>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os><family>windows</family></os>
+      </activation>
+      <properties>
+        <cmd>.cmd</cmd>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/maven-wrapper-plugin/src/it/projects/upgrade_with_existing_type/verify.groovy
+++ b/maven-wrapper-plugin/src/it/projects/upgrade_with_existing_type/verify.groovy
@@ -1,0 +1,37 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir,'mvnw').exists()
+assert new File(basedir,'mvnw.cmd').exists()
+assert new File(basedir,'.mvn/wrapper/maven-wrapper.jar').exists()
+
+wrapperProperties = new File(basedir,'.mvn/wrapper/maven-wrapper.properties')
+assert wrapperProperties.exists()
+
+Properties props = new Properties()
+wrapperProperties.withInputStream {
+    props.load(it)
+}
+
+// Assert that distribution type from previous Maven Wrapper is retained, without it being explicitly set via '-Dtype='
+assert props.distributionType.equals("bin")
+
+// Assert that distribution URL was updated to version specified via '-Dmaven='
+assert props.distributionUrl.endsWith("/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip")

--- a/maven-wrapper-plugin/src/site/markdown/usage.md
+++ b/maven-wrapper-plugin/src/site/markdown/usage.md
@@ -32,9 +32,9 @@ The scripts work like this:
 Apache Maven Wrapper Distribution Types
 -----
 
-There are 4 types available:
+There are 4 distribution types available:
 
-- **only-script** _(default)_: the lite implementation of `mvnw`/`mvnw.cmd` scripts will download the maven directly via wget or curl on *nix, or PowerShell on Windows,
+- **only-script** _(default for new installations)_: the lite implementation of `mvnw`/`mvnw.cmd` scripts will download the maven directly via wget or curl on *nix, or PowerShell on Windows,
 then exec/call the original `mvn`/`mvn.cmd` scripts of the downloaded maven distribution. This type does not use `maven-wrapper.jar` nor `MavenWrapperDownloader.java`,
 only the wrapper scripts are required.
 
@@ -46,13 +46,17 @@ The downside is that the project will contain a binary file in the source contro
 - **source**: Since Maven already requires Java to run, why not compile and run a classfile to download the maven-wrapper jar? 
 This type comes with a `.mvn/wrapper/MavenWrapperDownloader.java` which will be compiled and executed on the fly.
 
-The type can be specified with `mvn wrapper:wrapper -Dtype=x`, where x is any of the types listed above.
+The type can be specified with `mvn wrapper:wrapper -Dtype={type}`, where `{type}` is any of the types listed above.
+
+When `wrapper:wrapper` is run in a Maven module which contains a `.mvn/wrapper/maven-wrapper.properties` file, then the distribution type of the existing Maven Wrapper is used for the execution of the goal.
+This allows updating Maven Wrapper, without unintentionally changing the distribution type for an existing project.
+You can still use `-Dtype={type}` to change the distribution type for an existing installation. 
 
 Maven Version
 -------------
 By default the plugin will assume the same version as the Maven runtime (calling `mvn -v`). But you can pick a different version.
-Either call `mvn wrapper:wrapper -Dmaven=x`, where x is any valid Apache Maven Release, see https://search.maven.org/artifact/org.apache.maven/apache-maven
-Another option is adjust the `distributionUrl` in `.mvn/wrapper/maven-wrapper.properties`
+You can call `mvn wrapper:wrapper -Dmaven=x`, where `x` is any valid Apache Maven Release (see [Maven Central](https://central.sonatype.com/artifact/org.apache.maven/apache-maven/versions)).
+Another option is to adjust the `distributionUrl` in `.mvn/wrapper/maven-wrapper.properties`.
 
 Debugging
 ---------


### PR DESCRIPTION
Uses `distributionType` from `.mvn/wrapper/maven-wrapper.properties` by default, when present.

https://issues.apache.org/jira/browse/MWRAPPER-141