### PR TITLE
[MWRAPPER-146] Bad substitution on Windows if MVNW_REPOURL is set on script-only

### DIFF
--- a/maven-wrapper-distribution/src/resources/only-mvnw.cmd
+++ b/maven-wrapper-distribution/src/resources/only-mvnw.cmd
@@ -74,7 +74,7 @@ switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
 # maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
 if ($env:MVNW_REPOURL) {
   $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
-  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
 }
 $distributionUrlName = $distributionUrl -replace '^.*/',''
 $distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''

--- a/maven-wrapper-distribution/src/resources/only-mvnw.cmd
+++ b/maven-wrapper-distribution/src/resources/only-mvnw.cmd
@@ -73,7 +73,7 @@ switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
 # apply MVNW_REPOURL and calculate MAVEN_HOME
 # maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
 if ($env:MVNW_REPOURL) {
-  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
   $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
 }
 $distributionUrlName = $distributionUrl -replace '^.*/',''


### PR DESCRIPTION
Since version 3.3.0, we cannot download Maven distribution if we set `MVNW_REPOURL` on Windows platforms (Windows 10, Windows Server 2022) with script-only.

``` text
wrapperVersion=3.3.2
distributionType=only-script
distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.z
```ip

Current result (3.3.2)
``` text
PS C:\workspace\poc\maven-build> .\mvnw.cmd -v
icm : Exception lors de l'appel de « DownloadFile » avec « 2 » argument(s) : « Le serveur distant a retourné une erreur : (404) Introuvable. »
Au caractère Ligne:1 : 72
+ ... 'mvnw.cmd'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Invoke-Command], MethodInvocationException
    + FullyQualifiedErrorId : WebException,Microsoft.PowerShell.Commands.InvokeCommandCommand
Commande ECHO activée.
Cannot start maven from wrapper
```

Expected result was
``` text
PS C:\workspace\poc\maven-build> .\mvnw.cmd -v
COMMENTAIRES : Couldn't find MAVEN_HOME, downloading and installing it ...
COMMENTAIRES : Downloading from: https://nexus.local/repository/maven-repo/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
COMMENTAIRES : Downloading to: C:\Users\jahk04\AppData\Local\Temp\tmp1DCA.tmp.dir/apache-maven-3.9.9-bin.zip
```

If *MVNW_VERBOSE* is  also set to `true` we can have some hints

``` text
PS C:\workspace\poc\maven-build> .\mvnw.cmd -v
COMMENTAIRES : Couldn't find MAVEN_HOME, downloading and installing it ...
COMMENTAIRES : Downloading from: https://nexus.local/repository/maven-repo/maven/mvnd/https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
COMMENTAIRES : Downloading to: C:\Users\jahk04\AppData\Local\Temp\tmp950D.tmp.dir/apache-maven-3.9.9-bin.zip
icm : Exception lors de l'appel de «DownloadFile» avec «2» argument(s): «Le serveur distant a retourné une erreur:
(404) Introuvable.»
Au caractère Ligne:1 : 72
+ ... 'mvnw.cmd'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Invoke-Command], MethodInvocationException
    + FullyQualifiedErrorId : WebException,Microsoft.PowerShell.Commands.InvokeCommandCommand
Commande ECHO activée.
Cannot start maven from wrapper
```

`$env:MVNW_REPOURL` is concatened with mvnd context and the actual `distributionUrl` defined inside `.mvn/wrapper/maven-wrapper.properties`

Looking at script `mvnw.cmd`, it seems that the following block is at fault with two "bugs"
- `USE_MVND` evaluation is incorrect
- string substitution of `distributionUrl` is incorrect

``` diff
# apply MVNW_REPOURL and calculate MAVEN_HOME
# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
if ($env:MVNW_REPOURL) {
-  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
-  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
} 
```


I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)