### PR TITLE
[MWRAPPER-150] - Fails to validate checksums on MacOS Sequoia

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -284,7 +284,7 @@ done <"$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
 if [ -n "$wrapperSha256Sum" ]; then
   wrapperSha256Result=false
   if command -v sha256sum >/dev/null; then
-    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c - >/dev/null 2>&1; then
       wrapperSha256Result=true
     fi
   elif command -v shasum >/dev/null; then

--- a/maven-wrapper-distribution/src/resources/only-mvnw
+++ b/maven-wrapper-distribution/src/resources/only-mvnw
@@ -227,7 +227,7 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   elif command -v sha256sum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   elif command -v shasum >/dev/null; then


### PR DESCRIPTION
The version of `sha256sum` that ships with macOS Sequoia appears to have a bug where it does not read from stdin by default, even though its `man` page says, in part (emphasis added):

> In all cases, each file listed on the command line is processed separately.  **If no files are listed on the command line**, or a file name is given as -, input is taken from stdin instead.

…but invoking `sha256` as it appears in the `mvnw` script does not work as expected:

```sh
❯ echo '3d8f20ce6103913be8b52aef6d994e0c54705fb527324ceb9b835b338739c7a8  /Users/jon/REDACTED/.mvn/wrapper/maven-wrapper.jar' | sha256sum -c
usage: sha256sum [-bctwz] [files ...]
```

…which in turn results in a non-successful exit code, which in turn leads to a (rather alarming!) warning about a mismatched checksums and possible compromise.

Adding a `-` explicitly calls for `sha256sum` to read from stdin.

----

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

