### PR TITLE
Support Maven 4 by setting maven.mainClass to MavenCling

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -327,6 +327,7 @@ fi
 MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $*"
 export MAVEN_CMD_LINE_ARGS
 
+# Maven main class is here to fix maven 4.0.0-beta-5 through 4.0.0-rc-4
 MAVEN_MAIN_CLASS=org.apache.maven.cling.MavenCling
 WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 

--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -327,6 +327,7 @@ fi
 MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $*"
 export MAVEN_CMD_LINE_ARGS
 
+MAVEN_MAIN_CLASS=org.apache.maven.cling.MavenCling
 WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 # shellcheck disable=SC2086 # safe args
@@ -335,4 +336,5 @@ exec "$JAVACMD" \
   $MAVEN_DEBUG_OPTS \
   -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
   "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  "-Dmaven.mainClass=${MAVEN_MAIN_CLASS}" \
   ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/maven-wrapper-distribution/src/resources/mvnw.cmd
+++ b/maven-wrapper-distribution/src/resources/mvnw.cmd
@@ -117,6 +117,8 @@ for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do s
 
 SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+
+@REM Maven main class is here to fix maven 4.0.0-beta-5 through 4.0.0-rc-4
 set MAVEN_MAIN_CLASS=org.apache.maven.cling.MavenCling
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 

--- a/maven-wrapper-distribution/src/resources/mvnw.cmd
+++ b/maven-wrapper-distribution/src/resources/mvnw.cmd
@@ -117,6 +117,7 @@ for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do s
 
 SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+set MAVEN_MAIN_CLASS=org.apache.maven.cling.MavenCling
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
 set WRAPPER_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/@@project.version@@/maven-wrapper-@@project.version@@.jar"
@@ -182,6 +183,7 @@ set MAVEN_CMD_LINE_ARGS=%*
   %MAVEN_DEBUG_OPTS% ^
   -classpath %WRAPPER_JAR% ^
   "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
+  "-Dmaven.mainClass=%MAVEN_MAIN_CLASS%" ^
   %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
 if ERRORLEVEL 1 goto error
 goto end


### PR DESCRIPTION
Maven 4 changed how it works, as a result maven wrapper has been broken for a while.  You can see a working usage of this change here https://github.com/spotbugs/spotbugs-maven-plugin/actions/runs/17228298032.  If unable to see, see the github job here that customized updating wrapper to run on maven 4 here https://github.com/spotbugs/spotbugs-maven-plugin/blob/master/.github/workflows/it-maven-4.0.0.yaml by skipping the update to maven 4 and adjusting the wrapper to simply run maven 4 which is addressed by the changes here.