### PR TITLE
Ensure Path Traversal is fully addressed in MavenWrapperDownloader

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvn/wrapper/MavenWrapperDownloader.java
+++ b/maven-wrapper-distribution/src/resources/mvn/wrapper/MavenWrapperDownloader.java
@@ -45,8 +45,11 @@ public final class MavenWrapperDownloader {
         try {
             log(" - Downloader started");
             final URL wrapperUrl = URI.create(args[0]).toURL();
-            final String jarPath = args[1].replace("..", ""); // Sanitize path
-            final Path wrapperJarPath = Paths.get(jarPath).toAbsolutePath().normalize();
+            final Path baseDir = Paths.get(".").toAbsolutePath().normalize();
+            final Path wrapperJarPath = baseDir.resolve(args[1]).normalize();
+            if (!wrapperJarPath.startsWith(baseDir)) {
+                throw new IOException("Invalid path: outside of allowed directory");
+            }
             downloadFileFromURL(wrapperUrl, wrapperJarPath);
             log("Done");
         } catch (IOException e) {


### PR DESCRIPTION
The original sanitizing patch is not enough to prevent path traversal.  This approach more accurately deals with the security concern.