### PR TITLE
Fix wrong distribution URL output in only-script on some Unix systems

### DIFF
--- a/maven-wrapper-distribution/src/resources/only-mvnw
+++ b/maven-wrapper-distribution/src/resources/only-mvnw
@@ -170,16 +170,16 @@ fi
 
 mkdir -p -- "${MAVEN_HOME%/*}"
 
-# Download and Install Apache Maven
-verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
-verbose "Downloading from: $distributionUrl"
-verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
-
 # select .zip or .tar.gz
 if ! command -v unzip >/dev/null; then
   distributionUrl="${distributionUrl%.zip}.tar.gz"
   distributionUrlName="${distributionUrl##*/}"
 fi
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
 
 # verbose opt
 __MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''


### PR DESCRIPTION
*tl;dr:* moves output of distribution URL in `only-script` mode on Unix to after its final determination

Executing mvnw with the following config (correct `distributionSha256Sum` for the specified .zip file) on a Linux system without the `unzip` command not only fails because the .tar.gz file is downloaded as a fallback (see #285 for that) but also produces wrong logs when debugging with `MVNW_VERBOSE=true`:

```properties
wrapperVersion=3.3.4
distributionType=only-script
distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
distributionSha256Sum=0d7125e8c91097b36edb990ea5934e6c68b4440eef4ea96510a0f6815e7eeadb
```

The logs (using a Fedora container as an example of a distro without `unzip`) look like this:

```
$ MVNW_VERBOSE=true ./mvnw clean
Couldn't find MAVEN_HOME, downloading and installing it ...
Downloading from: https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
Downloading to: /tmp/tmp.dmwRYtbt0C/apache-maven-3.9.11-bin.zip
Found curl ... using curl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time   Current
                                 Dload  Upload   Total   Spent    Left   Speed
100 9060k  100 9060k    0     0  100.0M     0 --:--:-- --:--:-- --:--:-- 100.0M
Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised.
If you updated your Maven version, you need to update the specified distributionSha256Sum property.
```

Nothing in this log indicates that the .tar.gz file was downloaded instead of the .zip file. Line 3 and 4 even wrongly state the exact oposite. This does not help in realizing a fallback file was actually fetched for which the (otherwise possibly correct) `distributionSha256Sum` does not match.

This happens because the verbose messages are output immediately **before** the availability of `unzip` is determined and a fallback distribution URL and download path are possibly set.  Switching the order of output and check would greatly improve comprehensibility when trying to figure out what actually went wrong in the already convoluted scenario outlined above.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
