### PR TITLE
Fix incorrect path resolution for system profile under WOW64 (x86) redirection

### DIFF
--- a/maven-wrapper-distribution/src/resources/only-mvnw.cmd
+++ b/maven-wrapper-distribution/src/resources/only-mvnw.cmd
@@ -89,10 +89,11 @@ if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
 }
 
 $MAVEN_WRAPPER_DISTS = $null
-if ((Get-Item -Path $MAVEN_M2_PATH -Force).Target[0] -eq $null) {
-  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+$m2LinkTarget = (Get-Item -Path $MAVEN_M2_PATH -Force).Target
+if ($m2LinkTarget -is [array] -and $m2LinkTarget.Count -gt 0) {
+  $MAVEN_WRAPPER_DISTS = "$($m2LinkTarget[0])/wrapper/dists"
 } else {
-  $MAVEN_WRAPPER_DISTS = (Get-Item -Path $MAVEN_M2_PATH -Force).Target[0] + "/wrapper/dists"
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
 }
 
 $MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"


### PR DESCRIPTION
When `MAVEN_M2_PATH` points to a Windows system profile path (e.g., `C:\Windows\System32\config\systemprofile\.m2`),
running under an x86 (WOW64) process causes the path to be redirected to `C:\Windows\SysWOW64\config\systemprofile\.m2`.
In this case, `(Get-Item -Path $MAVEN_M2_PATH -Force).Target` returns `$null` instead of an array.

The previous code accessed `.Target[0]` directly, which throws an error when `.Target` is `$null` under an x86 process.

This fix stores `.Target` in a variable first and checks its type before indexing.


* Issue: https://github.com/apache/maven-wrapper/issues/395
* See also: https://github.com/fp024/win-file-link-test/blob/main/README_en.md

---

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
