### PR TITLE
fix(wrapper): preserve MVNW_REPOURL when exec maven in only-mvnw

### DIFF
--- a/maven-wrapper-distribution/src/resources/only-mvnw
+++ b/maven-wrapper-distribution/src/resources/only-mvnw
@@ -146,7 +146,7 @@ MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
 MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
 
 exec_maven() {
-  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD || :
   exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
 }
 


### PR DESCRIPTION
## Problem

In `only-mvnw` (the Linux-only-script distribution), the `exec_maven()` function unsets `MVNW_REPOURL` before exec-ing the Maven process:

```sh
unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
```

This means when the Maven Wrapper plugin runs (e.g., `mvn wrapper:wrapper`), it cannot read `MVNW_REPOURL` from the environment, so it falls back to the default repo URL written in `maven-wrapper.properties`.

**Impact:** Users who rely on `MVNW_REPOURL` to point to a custom mirror (common in corporate/proxied environments) cannot use `only-script` mode to update the wrapper — the custom URL is silently dropped.

The Windows counterpart (`only-mvnw.cmd`) does **not** unset `MVNW_REPOURL` — it only clears `MVNW_USERNAME` and `MVNW_PASSWORD`. This inconsistency confirms the bug.

## Fix

Remove `MVNW_REPOURL` from the `unset` line in `exec_maven()`, matching the behavior of `only-mvnw.cmd`.

## Reproduction

```sh
export MVNW_REPOURL=https://your-custom-mirror/repo
./mvnw org.apache.maven.plugins:maven-wrapper-plugin:3.3.3:wrapper -Dtype=only-script -Dmaven=3.9.11 -X
# Before fix: uses default https://repo.maven.apache.org/maven2
# After fix: correctly uses your-custom-mirror/repo
```

Fixes #368