### PR TITLE
fix(wrapper): guard against null Target property in only-mvnw.cmd

### DIFF
--- a/maven-wrapper-distribution/src/resources/only-mvnw.cmd
+++ b/maven-wrapper-distribution/src/resources/only-mvnw.cmd
@@ -89,10 +89,11 @@ if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
 }
 
 $MAVEN_WRAPPER_DISTS = $null
-if ((Get-Item -Path $MAVEN_M2_PATH -Force).Target[0] -eq $null) {
-  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+$m2Item = Get-Item -Path $MAVEN_M2_PATH -Force
+if ($m2Item.PSObject.Properties['Target'] -ne $null -and $m2Item.Target -ne $null) {
+  $MAVEN_WRAPPER_DISTS = $m2Item.Target[0] + "/wrapper/dists"
 } else {
-  $MAVEN_WRAPPER_DISTS = (Get-Item -Path $MAVEN_M2_PATH -Force).Target[0] + "/wrapper/dists"
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
 }
 
 $MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"


### PR DESCRIPTION
## Problem

`only-mvnw.cmd` crashes with **"Cannot index into a null array"** when running under the Local System account in a 32-bit process (typical for Jenkins Agents running as a Windows Service).

The root cause is on the symlink-resolution line:

```powershell
if ((Get-Item -Path $MAVEN_M2_PATH -Force).Target[0] -eq $null)
```

On the System Profile `.m2` path (`C:\WINDOWS\system32\config\systemprofile\.m2`) accessed from a 32-bit process, `Get-Item.Target` returns strictly `$null` (not an empty collection). Indexing `[0]` on `$null` throws `RuntimeException`.

## Fix

Cache the `Get-Item` result and check that the `Target` property exists **and** is non-null before attempting to index it. When `Target` is unavailable, fall through to the standard (non-symlink) path — which is the correct behavior for non-symlinked directories.

**Before:**
```powershell
if ((Get-Item -Path $MAVEN_M2_PATH -Force).Target[0] -eq $null) {
  ...
}
```

**After:**
```powershell
$m2Item = Get-Item -Path $MAVEN_M2_PATH -Force
if ($m2Item.PSObject.Properties["Target"] -ne $null -and $m2Item.Target -ne $null) {
  $MAVEN_WRAPPER_DISTS = $m2Item.Target[0] + "/wrapper/dists"
} else {
  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
}
```

Also swapped the branch order so the common case (non-symlink) is the `else` branch, avoiding unnecessary property inspection for the majority of users.

Fixes #395