### PR TITLE
fix(wrapper): trim property keys when parsing maven-wrapper.properties

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvnw
+++ b/maven-wrapper-distribution/src/resources/mvnw
@@ -225,6 +225,7 @@ else
     wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/@@project.version@@/maven-wrapper-@@project.version@@.jar"
   fi
   while IFS="=" read -r key value; do
+    key=$(trim "${key-}")
     case "$key" in wrapperUrl)
       wrapperUrl=$(trim "${value-}")
       break
@@ -281,6 +282,7 @@ fi
 # If specified, validate the SHA-256 sum of the Maven wrapper jar file
 wrapperSha256Sum=""
 while IFS="=" read -r key value; do
+  key=$(trim "${key-}")
   case "$key" in wrapperSha256Sum)
     wrapperSha256Sum=$(trim "${value-}")
     break

--- a/maven-wrapper-distribution/src/resources/only-mvnw
+++ b/maven-wrapper-distribution/src/resources/only-mvnw
@@ -110,6 +110,7 @@ scriptName="$(basename "$0")"
 
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
+  key=$(trim "${key-}")
   case "${key-}" in
   distributionUrl) distributionUrl=$(trim "${value-}") ;;
   distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;


### PR DESCRIPTION
When an IDE or code formatter adds spaces around `=` in
`maven-wrapper.properties` (e.g. `distributionUrl = https://...`),
the shell parser's `IFS="="` split leaves trailing whitespace
in the key variable. This causes the `case` pattern match to miss,
resulting in the error:

```
cannot read distributionUrl property in ./.mvn/wrapper/maven-wrapper.properties
```

The `trim()` function was already being applied to values but not to
keys. This commit adds `key=$(trim "${key-}")` in all three
property-parsing loops:

- **mvnw** — `wrapperUrl` download URL lookup (line ~227)
- **mvnw** — `wrapperSha256Sum` validation lookup (line ~284)
- **only-mvnw** — `distributionUrl` and `distributionSha256Sum` lookup (line ~112)

**Before fix:** `distributionUrl  = value` → key=`"distributionUrl  "` → no match → crash
**After fix:** key trimmed to `"distributionUrl"` → match succeeds

Fixes #369