### PR TITLE
fix(wrapper): replace mktemp with POSIX-compliant temp dir creation in only-mvnw

### DIFF
--- a/maven-wrapper-distribution/src/resources/only-mvnw
+++ b/maven-wrapper-distribution/src/resources/only-mvnw
@@ -160,8 +160,10 @@ case "${distributionUrl-}" in
 *) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
 esac
 
-# prepare tmp dir
-if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+# prepare tmp dir (POSIX-compatible: avoid mktemp which is not available in all shells)
+_tmp_base="${TMPDIR:-/tmp}"
+TMP_DOWNLOAD_DIR="$_tmp_base/maven_wrapper.$$_$(date +%s)"
+if mkdir -p -- "$TMP_DOWNLOAD_DIR" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
   clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
   trap clean HUP INT TERM EXIT
 else


### PR DESCRIPTION
## Summary

**Fixes #311**

`only-mvnw` declares `#!/bin/sh` shebang but uses `mktemp -d`, which is not POSIX-compliant and not available in all shells (e.g., ksh, some bash versions on AIX).

## Changes

Replace `mktemp -d` with a portable alternative using `TMPDIR`, PID ($$), and epoch timestamp to construct a unique temp directory path, then create it with `mkdir -p`.

This approach:
- Uses only POSIX shell builtins/commands available everywhere
- Maintains the same cleanup behavior via the existing `trap clean EXIT`
- Respects `TMPDIR` like the original code did

## Testing

- Verified the script still parses correctly
- The temp dir creation follows the same pattern used in the regular `mvnw` wrapper script