### PR TITLE
fix(wrapper): resolve script directory from mvnw.cmd location instead of CWD

### DIFF
--- a/maven-wrapper-distribution/src/resources/mvnw.cmd
+++ b/maven-wrapper-distribution/src/resources/mvnw.cmd
@@ -87,7 +87,9 @@ goto error
 set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
 IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
 
+pushd "%~dp0" >nul 2>&1
 set EXEC_DIR=%CD%
+popd >nul 2>&1
 set WDIR=%EXEC_DIR%
 :findBaseDir
 IF EXIST "%WDIR%"\.mvn goto baseDirFound


### PR DESCRIPTION
## Summary

Fixes #247 — **mvnw.cmd fails when run from a parent directory.**

## Problem

When invoking `mvnw.cmd` from a parent directory, the script sets `EXEC_DIR` using `%CD%` (current working directory) instead of resolving from the script's own location (`%~dp0`). This causes it to search for `.mvn/wrapper/maven-wrapper.properties` in the wrong directory:

```
The system cannot find the file C:\project\.mvn\wrapper\maven-wrapper.properties
```

The Unix `mvnw` script does not have this problem — it correctly uses `$(dirname "$0")` to find the base directory.

## Fix

Wrap the `EXEC_DIR` assignment with `pushd/popd %~dp0` so that `%CD%` resolves to the script's directory rather than the caller's working directory:

```diff
+pushd "%~dp0" >nul 2>&1
 set EXEC_DIR=%CD%
+popd >nul 2>&1
```

This matches the behavior of the Unix shell script and is the approach suggested in the issue report.
