### PR TITLE
Fail fast when unzip is missing but a distribution checksum is pinned (#425)

### DIFF
--- a/maven-wrapper-distribution/src/resources/only-mvnw
+++ b/maven-wrapper-distribution/src/resources/only-mvnw
@@ -172,6 +172,12 @@ mkdir -p -- "${MAVEN_HOME%/*}"
 
 # select .zip or .tar.gz
 if ! command -v unzip >/dev/null; then
+  if [ -n "${distributionSha256Sum-}" ]; then
+    die "Cannot validate the pinned distributionSha256Sum: it is computed for the .zip
+distribution, but 'unzip' is not available so mvnw would fall back to the .tar.gz.
+Install 'unzip', or remove 'distributionSha256Sum' from
+.mvn/wrapper/maven-wrapper.properties to allow the .tar.gz fallback."
+  fi
   distributionUrl="${distributionUrl%.zip}.tar.gz"
   distributionUrlName="${distributionUrl##*/}"
 fi


### PR DESCRIPTION
## What / Why

Fixes #425.

On systems without `unzip` (e.g. minimal images such as `eclipse-temurin`), the `only-script` `mvnw` silently rewrites the `distributionUrl` from `-bin.zip` to `-bin.tar.gz`. But `distributionSha256Sum` in `maven-wrapper.properties` is computed for the **`.zip`** — the wrapper plugin only ever writes the zip's checksum. The script then validates the downloaded `.tar.gz` against the `.zip`'s checksum, which always fails with:

```
Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised.
```

This is confusing to debug: the archive is genuine, and nothing is compromised — the checksum simply belongs to a different artifact than the one downloaded. There is no second property to hold the tar's checksum, so the fallback and checksum pinning are fundamentally incompatible.

## How

When `unzip` is unavailable **and** a `distributionSha256Sum` is pinned, refuse up front with an actionable message instead of downloading the `.tar.gz` and failing validation against the wrong checksum:

```
Cannot validate the pinned distributionSha256Sum: it is computed for the .zip
distribution, but 'unzip' is not available so mvnw would fall back to the .tar.gz.
Install 'unzip', or remove 'distributionSha256Sum' from
.mvn/wrapper/maven-wrapper.properties to allow the .tar.gz fallback.
```

The `.tar.gz` fallback is unchanged for the common case where no checksum is pinned. This never validates the wrong artifact and never skips validation, so it does not weaken the integrity guarantee — it fails safe, earlier and more clearly.

Only the POSIX `only-mvnw` is affected; `only-mvnw.cmd` handles `.zip` only and has no such fallback.

---

Following this checklist to help us incorporate your contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
  - The bug only manifests when `unzip` is absent, which the existing JUnit + Invoker IT harness cannot easily simulate; I kept this PR to the minimal fix. Happy to add a test if maintainers prefer a particular approach.
- [x] Run `mvn verify` to make sure basic checks pass.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)