### PR TITLE
Feature/maven version range

### DIFF
--- a/maven-wrapper-plugin/pom.xml
+++ b/maven-wrapper-plugin/pom.xml
@@ -125,6 +125,12 @@ under the License.
       <version>${version.mockito}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.6.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/maven-wrapper-plugin/src/it/projects/mavenversion_range/invoker.properties
+++ b/maven-wrapper-plugin/src/it/projects/mavenversion_range/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# `maven=[3.0,3.10-rc)` would fail on Windows
+# since the closing round bracket is not escaped
+invoker.os.family = !windows

--- a/maven-wrapper-plugin/src/it/projects/mavenversion_range/pom.xml
+++ b/maven-wrapper-plugin/src/it/projects/mavenversion_range/pom.xml
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.it.wrapper</groupId>
+  <artifactId>mavenversion_range</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <cmd></cmd>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>@version.exec-maven-plugin@</version>
+          <configuration>
+            <executable>mvnw${cmd}</executable>
+            <arguments>
+              <argument>-v</argument>
+            </arguments>
+            <environmentVariables>
+              <MVNW_VERBOSE>true</MVNW_VERBOSE>
+            </environmentVariables>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os><family>windows</family></os>
+      </activation>
+      <properties>
+        <cmd>.cmd</cmd>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/maven-wrapper-plugin/src/it/projects/mavenversion_range/test.properties
+++ b/maven-wrapper-plugin/src/it/projects/mavenversion_range/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+maven=[3.0,3.10-rc)

--- a/maven-wrapper-plugin/src/it/projects/mavenversion_range/verify.groovy
+++ b/maven-wrapper-plugin/src/it/projects/mavenversion_range/verify.groovy
@@ -1,0 +1,39 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir,'mvnw').exists()
+assert new File(basedir,'mvnw.cmd').exists()
+assert !(new File( basedir, 'mvnwDebug' ).exists())
+assert !(new File( basedir, 'mvnwDebug.cmd' ).exists())
+
+def wrapperProperties = new File(basedir,'.mvn/wrapper/maven-wrapper.properties')
+assert wrapperProperties.exists()
+
+Properties props = new Properties()
+wrapperProperties.withInputStream {
+    props.load(it)
+}
+
+// Assert that distribution URL was updated to the highest version automatically resolved
+// in the specified range: [3.0,3.10-rc)
+assert props.distributionUrl.endsWith("/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip")
+
+def log = new File(basedir, 'build.log').text
+assert log.contains('Apache Maven 3.9.16')

--- a/maven-wrapper-plugin/src/it/projects/mavenversion_range_windows/invoker.properties
+++ b/maven-wrapper-plugin/src/it/projects/mavenversion_range_windows/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# `maven="[3.0,3.10-rc)"` would fail on non-Windows OS
+# since the value is quoted
+invoker.os.family = windows

--- a/maven-wrapper-plugin/src/it/projects/mavenversion_range_windows/pom.xml
+++ b/maven-wrapper-plugin/src/it/projects/mavenversion_range_windows/pom.xml
@@ -1,0 +1,66 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.it.wrapper</groupId>
+  <artifactId>mavenversion_range_windows</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <cmd></cmd>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>@version.exec-maven-plugin@</version>
+          <configuration>
+            <executable>mvnw${cmd}</executable>
+            <arguments>
+              <argument>-v</argument>
+            </arguments>
+            <environmentVariables>
+              <MVNW_VERBOSE>true</MVNW_VERBOSE>
+            </environmentVariables>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os><family>windows</family></os>
+      </activation>
+      <properties>
+        <cmd>.cmd</cmd>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/maven-wrapper-plugin/src/it/projects/mavenversion_range_windows/test.properties
+++ b/maven-wrapper-plugin/src/it/projects/mavenversion_range_windows/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+maven="[3.0,3.10-rc)"

--- a/maven-wrapper-plugin/src/it/projects/mavenversion_range_windows/verify.groovy
+++ b/maven-wrapper-plugin/src/it/projects/mavenversion_range_windows/verify.groovy
@@ -1,0 +1,39 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir,'mvnw').exists()
+assert new File(basedir,'mvnw.cmd').exists()
+assert !(new File( basedir, 'mvnwDebug' ).exists())
+assert !(new File( basedir, 'mvnwDebug.cmd' ).exists())
+
+def wrapperProperties = new File(basedir,'.mvn/wrapper/maven-wrapper.properties')
+assert wrapperProperties.exists()
+
+Properties props = new Properties()
+wrapperProperties.withInputStream {
+    props.load(it)
+}
+
+// Assert that distribution URL was updated to the highest version automatically resolved
+// in the specified range: [3.0,3.10-rc)
+assert props.distributionUrl.endsWith("/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip")
+
+def log = new File(basedir, 'build.log').text
+assert log.contains('Apache Maven 3.9.16')

--- a/maven-wrapper-plugin/src/main/java/org/apache/maven/plugins/wrapper/WrapperMojo.java
+++ b/maven-wrapper-plugin/src/main/java/org/apache/maven/plugins/wrapper/WrapperMojo.java
@@ -29,10 +29,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import org.apache.maven.Maven;
+import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -48,7 +50,11 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.version.Version;
 
+import static java.util.Comparator.reverseOrder;
 import static org.apache.maven.shared.utils.logging.MessageUtils.buffer;
 
 /**
@@ -69,9 +75,11 @@ public class WrapperMojo extends AbstractMojo {
 
     /**
      * The version of Maven to require, default value is the Runtime version of Maven.
-     * Can be any valid release above 2.0.9
+     * Can be any valid release above 2.0.9.
+     * Automatic version resolution is supported via {@link VersionRange} such as {@code [3.0,4.0-alpha)}.
      *
      * @since 3.0.0
+     * @see <a href="https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification">Dependency Version Requirement Specification</a>
      */
     @Parameter(property = "maven")
     private String mavenVersion;
@@ -211,7 +219,7 @@ public class WrapperMojo extends AbstractMojo {
                     + " cannot work with mvnd, please set type to '" + TYPE_ONLY_SCRIPT + "'.");
         }
 
-        mavenVersion = getVersion(mavenVersion, Maven.class, "org.apache.maven/maven-core");
+        mavenVersion = resolveMavenVersion(getVersion(mavenVersion, Maven.class, "org.apache.maven/maven-core"));
         String wrapperVersion = getVersion(null, this.getClass(), "org.apache.maven.plugins/maven-wrapper-plugin");
 
         final Artifact artifact = downloadWrapperDistribution(wrapperVersion);
@@ -374,6 +382,36 @@ public class WrapperMojo extends AbstractMojo {
             }
         }
         return version;
+    }
+
+    /**
+     * Resolves the actual Maven version to download, given the range in {@link WrapperMojo#mavenVersion}.
+     * If the requested range could not be parsed, the version provided as input is returned.
+     *
+     * @param version the Maven version range
+     *
+     * @return the highest release version according to the provided range
+     * @see <a href="https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification">Dependency Version Requirement Specification</a>
+     */
+    String resolveMavenVersion(String version) {
+        try {
+            Artifact artifact = new DefaultArtifact("org.apache.maven:apache-maven:" + version);
+            VersionRangeRequest request = new VersionRangeRequest(
+                    artifact, session.getCurrentProject().getRemotePluginRepositories(), "wrapper");
+
+            List<Version> versions = repositorySystem
+                    .resolveVersionRange(repositorySystemSession, request)
+                    .getVersions();
+            versions.sort(reverseOrder());
+
+            return versions.stream()
+                    .map(Version::toString)
+                    .filter(v -> !artifact.setVersion(v).isSnapshot())
+                    .findFirst()
+                    .orElse(version);
+        } catch (VersionRangeResolutionException e) {
+            return version;
+        }
     }
 
     /**

--- a/maven-wrapper-plugin/src/site/markdown/usage.md
+++ b/maven-wrapper-plugin/src/site/markdown/usage.md
@@ -55,8 +55,12 @@ You can still use `-Dtype={type}` to change the distribution type for an existin
 Maven Version
 -------------
 By default the plugin will assume the same version as the Maven runtime (calling `mvn -v`). But you can pick a different version.
-You can call `mvn wrapper:wrapper -Dmaven=x`, where `x` is any valid Apache Maven Release (see [Maven Central](https://central.sonatype.com/artifact/org.apache.maven/apache-maven/versions)).
-Another option is to adjust the `distributionUrl` in `.mvn/wrapper/maven-wrapper.properties`.
+You can call `mvn wrapper:wrapper -Dmaven=x`, where `x` is any valid Apache Maven Release (see [Maven Central](https://central.sonatype.com/artifact/org.apache.maven/apache-maven/versions))
+or a version range (see [Dependency Version Requirement Specification](https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification)).
+In the latter case, mind that bash interprets round brackets as special characters to identify subshells, so they must be escaped
+either with a backslash as in `-Dmaven=[3.0,4.0\)` or the whole argument must be quoted like `-Dmaven="[3.0,4.0)"`.
+
+Another option is to adjust the `distributionUrl` in `.mvn/wrapper/maven-wrapper.properties` with the specific version.
 
 Debugging
 ---------

--- a/maven-wrapper-plugin/src/test/java/org/apache/maven/plugins/wrapper/WrapperMojoTest.java
+++ b/maven-wrapper-plugin/src/test/java/org/apache/maven/plugins/wrapper/WrapperMojoTest.java
@@ -18,17 +18,32 @@
  */
 package org.apache.maven.plugins.wrapper;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
+import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.version.Version;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +55,21 @@ class WrapperMojoTest {
     @Mock
     private RepositorySystemSession repositorySystemSession;
 
+    @Mock
+    private MavenProject project;
+
+    @Mock
+    private Version version1;
+
+    @Mock
+    private Version version2;
+
+    @Mock
+    private MavenSession session;
+
+    @Captor
+    private ArgumentCaptor<VersionRangeRequest> requestCaptor;
+
     @InjectMocks
     private WrapperMojo wrapperMojo;
 
@@ -47,6 +77,56 @@ class WrapperMojoTest {
     void setupMocks() {
         when(repositorySystem.newResolutionRepositories(same(repositorySystemSession), anyList()))
                 .then(i -> i.getArguments()[1]);
+    }
+
+    @Test
+    void resolveMavenVersion() throws VersionRangeResolutionException {
+        String versionRange = "versionRange";
+        String resolvedVersion1 = "resolvedVersion1-SNAPSHOT";
+        String resolvedVersion2 = "resolvedVersion2";
+        List<RemoteRepository> remoteRepositories = Collections.emptyList();
+        VersionRangeResult result =
+                new VersionRangeResult(new VersionRangeRequest()).setVersions(Arrays.asList(version1, version2));
+
+        when(repositorySystem.resolveVersionRange(eq(repositorySystemSession), requestCaptor.capture()))
+                .thenReturn(result);
+        when(session.getCurrentProject()).thenReturn(project);
+        when(project.getRemotePluginRepositories()).thenReturn(remoteRepositories);
+        when(version1.toString()).thenReturn(resolvedVersion1);
+        when(version2.toString()).thenReturn(resolvedVersion2);
+
+        assertEquals(resolvedVersion2, wrapperMojo.resolveMavenVersion(versionRange));
+
+        VersionRangeRequest capturedRequest = requestCaptor.getValue();
+        assertEquals(remoteRepositories, capturedRequest.getRepositories());
+        assertEquals("wrapper", capturedRequest.getRequestContext());
+
+        Artifact artifact = capturedRequest.getArtifact();
+        assertEquals("org.apache.maven", artifact.getGroupId());
+        assertEquals("apache-maven", artifact.getArtifactId());
+        assertEquals(versionRange, artifact.getVersion());
+    }
+
+    @Test
+    void resolveMavenVersionException() throws VersionRangeResolutionException {
+        String versionRange = "versionRange";
+        List<RemoteRepository> remoteRepositories = Collections.emptyList();
+
+        when(repositorySystem.resolveVersionRange(eq(repositorySystemSession), requestCaptor.capture()))
+                .thenThrow(VersionRangeResolutionException.class);
+        when(session.getCurrentProject()).thenReturn(project);
+        when(project.getRemotePluginRepositories()).thenReturn(remoteRepositories);
+
+        assertEquals(versionRange, wrapperMojo.resolveMavenVersion(versionRange));
+
+        VersionRangeRequest capturedRequest = requestCaptor.getValue();
+        assertEquals(remoteRepositories, capturedRequest.getRepositories());
+        assertEquals("wrapper", capturedRequest.getRequestContext());
+
+        Artifact artifact = capturedRequest.getArtifact();
+        assertEquals("org.apache.maven", artifact.getGroupId());
+        assertEquals("apache-maven", artifact.getArtifactId());
+        assertEquals(versionRange, artifact.getVersion());
     }
 
     @Test


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
---

# Problem
As per the [usage docs](https://maven.apache.org/tools/wrapper/maven-wrapper-plugin/usage.html), bumping the Maven version requires manually going on [Maven Central](https://central.sonatype.com/artifact/org.apache.maven/apache-maven/versions) to get the latest. It would be nice having the plugin resolve the highest available version automatically.

# Proposed solution
Maven already supports [Dependency Version Requirement Specification](https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification), allowing the definition of a range instead of a fixed one. Though it's not advisable to rely on such a mechanism to manage regular dependencies of an application for the sake of reproducible builds, the wrapper is an external tool for which this issue doesn't apply.

Available Maven versions are taken from [maven-metadata.xml](https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/maven-metadata.xml).

# Rationale
Having a native way to automatically bump the Maven version let us schedule a simple wrapper execution. For instance:
* `./mvnw wrapper:wrapper -Dmaven=3.9.16`: fixed versions are considered valid ranges, so no breaking change.
* `./mvnw wrapper:wrapper -Dmaven="[3.0,4.0-alpha)"`: allows the resolution of the latest `3.x.x` version, excluding currently non-stable `4.x.x` versions.

Moreover, this is done without relying on external tools such as GitHub actions (as proposed in #331) or bots like Renovate (as proposed in #249).